### PR TITLE
Refactor/train pipeline separate dataset

### DIFF
--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -31,6 +31,7 @@ def main():
         split_by_session(
             input_dataset_path=config.paths.data_yolo_merged,
             output_dataset_path=config.paths.data_yolo,
+            yaml_path=config.paths.yaml,
             split_ratio=config.dataset.split_cfg.model_dump(),
             seed=config.dataset.seed,
         )
@@ -38,7 +39,6 @@ def main():
     # Inspeccionar el dataset ya preparado
     if config.pipeline.inspect:
         inspector = DatasetInspector(config.paths.data_yolo)
-        
         # Imprime el resumen del dataset
         inspector.summary_split()
 

--- a/run_train.py
+++ b/run_train.py
@@ -1,23 +1,13 @@
-from src.data.data_yolo import descargar_dataset
 from src.training.training_yolo import entrenar_yolo
-from src.utils.config_loader import BASE_DIR, ConfigLoader
+from src.utils.config_loader import ConfigLoader
 
 
 def main():
     config = ConfigLoader("train").load()
-    # Descargar dataset desde Roboflow
-    descargar_dataset(
-        version=config.roboflow.version,
-        api_key=config.roboflow.api_key,
-        yolo_ver=config.roboflow.yolo_ver,
-        base_path=BASE_DIR,
-        workspace=config.roboflow.workspace,
-        project_name=config.roboflow.project_name,
-    )
 
     # Entrenar modelo YOLO
     entrenar_yolo(
-        base_path=BASE_DIR,
+        yaml_path=config.paths.yaml,
         version=config.training.version,
         imgsz=config.training.imgsz,
         batch=config.training.batch,

--- a/src/data/split_dataset.py
+++ b/src/data/split_dataset.py
@@ -4,6 +4,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, Set
 
+import yaml
+
 from src.utils.files import parse_filename
 
 
@@ -139,14 +141,60 @@ def copy_split_files(
             shutil.copy2(label_source, dest_label)
 
 
+def generate_train_yaml(
+    yaml_original: str,
+    dataset_root: str,
+    output_yaml: str | None = None,
+):
+    """
+    Genera un data.yaml listo para entrenamiento YOLO
+    agregando path, train, val y test según existan.
+
+    Si output_yaml es None, sobreescribe yaml_original.
+    """
+
+    yaml_original = Path(yaml_original)
+    dataset_root = Path(dataset_root)
+
+    if output_yaml is None:
+        output_yaml = yaml_original
+    else:
+        output_yaml = Path(output_yaml)
+
+    # Leer el YAML original para obtener nc y names
+    with open(yaml_original, "r") as f:
+        data = yaml.safe_load(f)
+
+    # Mantengo nc y names
+    new_yaml = {
+        "names": data["names"],
+        "nc": data["nc"],
+        "path": str(dataset_root.resolve() / "split"),
+        "train": "train/images",
+        "val": "val/images",
+    }
+
+    # Si existe test lo agrego
+    if (dataset_root / "test/images").exists():
+        new_yaml["test"] = "test/images"
+
+    # Guardar el nuevo YAML en output_yaml
+    with open(output_yaml, "w") as f:
+        yaml.safe_dump(new_yaml, f, sort_keys=False)
+
+    print(f"YAML de entrenamiento generado en: {output_yaml}")
+
+
 def split_by_session(
     input_dataset_path: str,
     output_dataset_path: str,
+    yaml_path: str,
     split_ratio: dict[str, float],
     seed: int = 42,
 ) -> None:
     input_path = Path(input_dataset_path)
     output_path = Path(output_dataset_path)
+
     # Validar el split_ratio
     validate_split_ratio(split_ratio)
 
@@ -176,3 +224,9 @@ def split_by_session(
 
     # Copiar archivos a sus carpetas correspondientes según el split asignado a su sesión
     copy_split_files(input_path, output_path, split_sessions)
+
+    # Generar el YAML de entrenamiento para YOLO
+    generate_train_yaml(
+        yaml_original=yaml_path,
+        dataset_root=output_dataset_path,
+    )

--- a/src/training/training_yolo.py
+++ b/src/training/training_yolo.py
@@ -6,7 +6,7 @@ from ultralytics import YOLO
 
 
 def entrenar_yolo(
-    base_path=None,
+    yaml_path=None,
     version=8,
     imgsz=1440,
     batch=2,
@@ -31,6 +31,8 @@ def entrenar_yolo(
     Returns:
         model: objeto YOLO entrenado
     """
+    yaml_path = Path(yaml_path)
+
     # Verifico si PyTorch, CUDA y torchvision están instalados correctamente
     print(torch.__version__)
     print(torch.cuda.is_available())
@@ -40,10 +42,6 @@ def entrenar_yolo(
 
     # Cargo el modelo YOLO preentrenado
     model = YOLO("yolov8n.pt")
-
-    # Defino la ruta al archivo data.yaml del dataset
-    base_path = Path(base_path) if base_path else Path.cwd()
-    yaml_path = base_path / f"data/yolo/Proyecto_final_electronica-{version}/data.yaml"
 
     if not yaml_path.exists():
         raise FileNotFoundError(f"No se encontró el archivo YAML en {yaml_path}")

--- a/src/utils/config/types/config_types_pc_dataset.py
+++ b/src/utils/config/types/config_types_pc_dataset.py
@@ -31,6 +31,7 @@ class PathsConfig(BaseModel):
     data_yolo: str | None = None
     data_yolo_raw: str | None = None
     data_yolo_merged: str | None = None
+    yaml: str | None = None
 
 
 class AppConfig(BaseModel):

--- a/src/utils/config/types/config_types_pc_train.py
+++ b/src/utils/config/types/config_types_pc_train.py
@@ -1,14 +1,6 @@
 from pydantic import BaseModel
 
 
-class RoboflowConfig(BaseModel):
-    api_key: str | None = None
-    version: int | None = None
-    workspace: str | None = None
-    project_name: str | None = None
-    yolo_ver: str | None = None
-
-
 class TrainingConfig(BaseModel):
     version: int | None = None
     imgsz: int | None = None
@@ -19,6 +11,10 @@ class TrainingConfig(BaseModel):
     workers: int | None = None
 
 
+class PathConfig(BaseModel):
+    yaml: str | None = None
+
+
 class AppConfig(BaseModel):
-    roboflow: RoboflowConfig
     training: TrainingConfig
+    paths: PathConfig


### PR DESCRIPTION
# Eliminación de descarga del dataset desde el pipeline de entrenamiento

## Objetivo
Separar responsabilidades dentro del pipeline, desacoplando la descarga del dataset del proceso de entrenamiento.
Además, se incorpora la generación automática del `data.yaml` para YOLO luego del proceso de split, permitiendo que el entrenamiento consuma directamente un dataset ya preparado.

## Cambios realizados
- Se elimina `descargar_dataset` de `run_train.py`.
- El entrenamiento ahora asume que el dataset ya fue preparado previamente.
- Se agrega la función `generate_train_yaml` en `src/data/split_dataset.py`.
- Luego de ejecutar `split_by_session`, se genera automáticamente un `data.yaml` listo para entrenamiento.