### PR TITLE
Feature/duo multi dataset

### DIFF
--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -34,6 +34,7 @@ def main():
             yaml_path=config.paths.yaml,
             split_ratio=config.dataset.split_cfg.model_dump(),
             seed=config.dataset.seed,
+            mode_sessions=config.dataset.mode_sessions,
         )
 
     # Inspeccionar el dataset ya preparado

--- a/raspberry/capture_dataset.py
+++ b/raspberry/capture_dataset.py
@@ -1,25 +1,65 @@
+import argparse
+
 from src.camera.camera_utils import capture_photos, init_camera
 
 from src.utils.config_loader import ConfigLoader
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Captura de imágenes para dataset")
+    parser.add_argument(
+        "--mode", choices=["iso", "duo", "multi"], required=True, help="Modo de captura"
+    )
+
+    parser.add_argument("--product1", type=str, help="Primer producto")
+    parser.add_argument("--product2", type=str, help="Segundo producto (para duo)")
+    parser.add_argument(
+        "--session",
+        type=int,
+        help="Número de sesión manual (si no se pasa, se calcula automáticamente)",
+    )
+    args = parser.parse_args()
+
     # Cargar la configuración
     config = ConfigLoader(func_name="capture").load()
 
     # Inicializar la cámara
     picam2 = init_camera(resolution=config.cam.resolution)
 
-    # Directorio donde guardar las fotos
-    output_dir = config.cam.output_dir + "/" + config.cam.clase
+    # -------- definir producto según modo --------
+    if args.mode == "iso":
+        if not args.product1:
+            raise ValueError("En modo iso debes pasar --product1")
+
+        filename_prefix = args.product1
+        output_dir = f"{config.cam.output_dir}/{filename_prefix}"
+        n_photos = config.cam.n_photos
+
+    elif args.mode == "duo":
+        if not args.product1 or not args.product2:
+            raise ValueError("En modo duo debes pasar --product1 y --product2")
+
+        productos = sorted([args.product1, args.product2])
+        filename_prefix = "_".join(productos)
+
+        output_dir = f"{config.cam.output_dir}/duo/{filename_prefix}"
+        n_photos = config.cam.n_photos
+
+    elif args.mode == "multi":
+        filename_prefix = "multi"
+        output_dir = f"{config.cam.output_dir}/multi"
+        n_photos = 1
+
+    # -------- captura --------
 
     # Capturar fotos
     capture_photos(
         picam2,
         output_dir=output_dir,
-        producto=config.cam.clase,
-        n_photos=config.cam.n_photos,
+        filename_prefix=filename_prefix,
+        n_photos=n_photos,
         delay=config.cam.delay,
+        session=args.session,
     )
 
 

--- a/raspberry/src/camera/camera_utils.py
+++ b/raspberry/src/camera/camera_utils.py
@@ -46,16 +46,34 @@ def get_next_session(output_dir: Path, producto: str) -> int:
     return max(sessions, default=0) + 1
 
 
-def capture_photos(picam2, output_dir, producto, n_photos=40, delay=0.5):
+def get_next_frame(output_dir: Path, filename_prefix: str, session: int) -> int:
+    # Busca el número de frame más alto para el producto y sesión dados, y devuelve el siguiente número disponible
+
+    # Defino formato del nombre de archivo: {filename_prefix}_s{session}_{n_frame}.jpg
+    pattern = re.compile(rf"{filename_prefix}_s{session:02d}_(\d+)\.jpg")
+    frames = []
+
+    for img in output_dir.glob(f"{filename_prefix}_s{session:02d}_*.jpg"):
+        match = pattern.match(img.name)
+        if match:
+            frames.append(int(match.group(1)))
+
+    return max(frames, default=-1) + 1
+
+
+def capture_photos(
+    picam2, output_dir, filename_prefix, n_photos=40, delay=0.5, session=None
+):
     """
     Captura una serie de fotos con la cámara y guarda información de exposición.
 
     Parámetros:
     - picam2 (Picamera2): Objeto de cámara inicializado.
     - output_dir (str): Carpeta donde se guardarán las fotos.
-    - producto (str): Nombre del producto para nombrar las fotos.
+    - filename_prefix (str): Prefijo para nombrar las fotos.
     - n_photos (int): Cantidad de fotos a capturar.
     - delay (float): Tiempo de espera entre fotos, en segundos.
+    - session (int, opcional): Número de sesión manual. Si no se proporciona, se calcula automáticamente.
     """
     # Crea un objeto Path
     output_dir = Path(output_dir)
@@ -63,11 +81,15 @@ def capture_photos(picam2, output_dir, producto, n_photos=40, delay=0.5):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Obtiene el número de sesión siguiente para evitar sobrescribir fotos anteriores
-    session = get_next_session(output_dir, producto)
+    if session is None:
+        session = get_next_session(output_dir, filename_prefix)
 
-    for frame in range(n_photos):
-        # Genera un nombre de archivo con formato: producto_sXX_YYYY.jpg
-        filename = output_dir / f"{producto}_s{session:02d}_{frame:04d}.jpg"
+    # Obtiene el número de frame siguiente para evitar sobrescribir fotos anteriores
+    frame = get_next_frame(output_dir, filename_prefix, session)
+
+    for i in range(n_photos):
+        # Construye el nombre del archivo con el formato: {filename_prefix}_s{session}_{n_frame}.jpg
+        filename = output_dir / f"{filename_prefix}_s{session:02d}_{frame:04d}.jpg"
 
         # Captura una imagen
         request = picam2.capture_request()
@@ -79,11 +101,13 @@ def capture_photos(picam2, output_dir, producto, n_photos=40, delay=0.5):
         gain = metadata.get("AnalogueGain", "N/A")
 
         # Muestra por consola información de la captura
-        print(f"Foto {frame + 1}/{n_photos} -> {filename}")
+        print(f"Foto {i + 1}/{n_photos} -> {filename}")
         print(f"Exposición: {exposure_time} µs | Ganancia: {gain}")
 
         # Libera el request
         request.release()
+        # Incrementa el número de frame para la siguiente foto
+        frame += 1
         time.sleep(delay)
 
     print("Capturas finalizadas.")

--- a/src/data/split_dataset.py
+++ b/src/data/split_dataset.py
@@ -98,11 +98,30 @@ def assign_sessions_to_splits(
     return session_to_split
 
 
-def common_sessions(product_sessions: dict[str, set[str]]) -> set[str]:
-    # Devuelve el conjunto de sesiones que están presentes en todos los productos
+def collect_sessions(
+    product_sessions: dict[str, set[str]],
+    mode: str = "all",
+) -> set[str]:
+    """
+    Recolecta sesiones según el modo:
+    - "common": solo sesiones presentes en todos los productos
+    - "all": todas las sesiones disponibles
+    """
+
     if not product_sessions:
         return set()
-    return set.intersection(*product_sessions.values())
+
+    if mode == "common":
+        return set.intersection(*product_sessions.values())
+
+    elif mode == "all":
+        all_sessions = set()
+        for sessions in product_sessions.values():
+            all_sessions.update(sessions)
+        return all_sessions
+
+    else:
+        raise ValueError("mode debe ser 'common' o 'all'")
 
 
 def copy_split_files(
@@ -191,6 +210,7 @@ def split_by_session(
     yaml_path: str,
     split_ratio: dict[str, float],
     seed: int = 42,
+    mode_sessions: str = "all",
 ) -> None:
     input_path = Path(input_dataset_path)
     output_path = Path(output_dataset_path)
@@ -217,10 +237,10 @@ def split_by_session(
     sessions_by_product = get_sessions_by_product(images)
 
     # Obtener sesiones comunes a todos los productos
-    common = sorted(common_sessions(sessions_by_product))
+    list_sessions = sorted(collect_sessions(sessions_by_product, mode=mode_sessions))
 
     # Asignar sesiones a splits según el split_ratio y el seed para reproducibilidad
-    split_sessions = assign_sessions_to_splits(common, split_ratio, seed=seed)
+    split_sessions = assign_sessions_to_splits(list_sessions, split_ratio, seed=seed)
 
     # Copiar archivos a sus carpetas correspondientes según el split asignado a su sesión
     copy_split_files(input_path, output_path, split_sessions)

--- a/src/utils/config/types/config_types_pc_dataset.py
+++ b/src/utils/config/types/config_types_pc_dataset.py
@@ -25,6 +25,7 @@ class DatasetSplitConfig(BaseModel):
 class DatasetConfig(BaseModel):
     split_cfg: DatasetSplitConfig
     seed: int = 42
+    mode_sessions: str = "all"  # "all", "common"
 
 
 class PathsConfig(BaseModel):


### PR DESCRIPTION
## Objetivo
Este PR introduce mejoras en la captura de imágenes y en el pipeline de generación de dataset, agregando mayor flexibilidad en el manejo de sesiones y modos de captura.

## Cambios principales
### Captura de imágenes (raspberry)

Se agregan modos de captura mediante argumentos CLI:
- `iso`: captura de un solo producto
- `duo`: captura de dos productos combinados
- `multi`: captura genérica

Nuevos argumentos:
- `--mode` (iso, duo o multi)
- `--product1`, `--product2`
- `--session` (opcional, permite forzar número de sesión)

Se redefine la lógica de output_dir y filename_prefix según el modo.

### Manejo de sesiones y frames

Se agrega get_next_frame para evitar sobreescritura de imágenes dentro de una sesión.

### Split de dataset (src/data)

Se reemplaza `common_sessions` por `collect_sessions`:
- `"common"`: sesiones presentes en todos los productos
- `"all"`: todas las sesiones disponibles
